### PR TITLE
Add identifier_format option

### DIFF
--- a/query_select.go
+++ b/query_select.go
@@ -11,6 +11,7 @@ func Db(args ...interface{}) Term {
 
 type TableOpts struct {
 	UseOutdated interface{} `gorethink:"use_outdated,omitempty"`
+	IdentifierFormat interface{} `gorethink:"identifier_format,omitempty"`
 }
 
 func (o *TableOpts) toMap() map[string]interface{} {


### PR DESCRIPTION
I stumbled uppon that possible optional argument [here](http://rethinkdb.com/docs/system-stats/), apparently if you define it as "uuid" the tables and database names come out as their respective uuids.